### PR TITLE
updated redux-saga dep in package.json to be more lenient

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,12 +25,12 @@
   },
   "peerDependencies": {
     "eslint": "^2.0.0 || ^3.0.0",
-    "redux-saga": "^0.11.1"
+    "redux-saga": ">= 0.11.1 < 1"
   },
   "devDependencies": {
     "eslint": "3.6.1",
     "mocha": "3.1.0",
-    "redux-saga": "0.11.1"
+    "redux-saga": ">= 0.11.1 < 1"
   },
   "keywords": [
     "eslint",


### PR DESCRIPTION
instead of using 0.x, i thought this approach of specifying a range would be more appropriate to enforce people don't try to use this plugin with too old a version of redux-saga.

I tried to install my fork on my project with these changes and I didn't get an error from npm.