### PR TITLE
Add entry for recommended configuration to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,15 @@ And add it to your `.eslintrc` file:
 * Ensure effects are yielded - [yield-effects](docs/rules/yield-effects.md)
 * Prevent usage of yield in race entries - [no-yield-in-race](docs/rules/no-yield-in-race.md)
 * Ensures error handling on sagas - [no-unhandled-errors](docs/rules/no-unhandled-errors.md)
+
+## Recommended configuration
+
+This plugin exports the `recommended` configuration that enforces all the rules. To use it, add following property to `.eslintrc` file:
+
+```json
+{
+  "extends": [
+    "plugin:redux-saga/recommended"
+  ]
+}
+```


### PR DESCRIPTION
Looks like this module exports `recommended` configuration [here][configuration-link]. This is almost a default option for eslint plugins, but it would be nice to have entry about this in README.

[configuration-link]: https://github.com/pke/eslint-plugin-redux-saga/blob/develop/index.js#L17