### PR TITLE
Add redux-saga >= 1.0.0 to peerDependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ env:
   matrix:
     - REDUX_SAGA_VERSION=^0.11.1
     - REDUX_SAGA_VERSION=^1.0.0
-before_script: npm install redux-saga@${REDUX_SAGA_VERSION}
+after_install: npm install redux-saga@${REDUX_SAGA_VERSION}

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,8 @@ language: node_js
 node_js:
   - 6.2.0
   - 10
+env:
+  matrix:
+    - REDUX_SAGA_VERSION=^0.11.1
+    - REDUX_SAGA_VERSION=^1.0.0
+before_script: npm install redux-saga@${REDUX_SAGA_VERSION}

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "peerDependencies": {
     "eslint": ">= 4.1.0",
-    "redux-saga": ">= 0.11.1 < 1 || 1.0.0-beta.3"
+    "redux-saga": ">= 0.11.1 < 1 || >= 1.0.0"
   },
   "devDependencies": {
     "eslint": "4.19.1",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "eslint": "4.19.1",
     "mocha": "~5.2.0",
-    "redux-saga": ">= 0.11.1 < 1"
+    "redux-saga": ">= 0.11.1 < 1 || >= 1.0.0"
   },
   "keywords": [
     "eslint",


### PR DESCRIPTION
This PR should suppress the following warning when used with [redux-saga](https://redux-saga.js.org/) 1.0.0, which [has been released](https://github.com/redux-saga/redux-saga/releases/tag/v1.0.0) recently:

```log
warning "eslint-config-[...] > eslint-plugin-redux-saga@0.10.0" has incorrect peer dependency "redux-saga@>= 0.11.1 < 1 || 1.0.0-beta.3".
```

### PR

- [x] Update `peerDependencies` and `devDependencies` (`devDependencies` defaults to `1.x`)
- [x] Update Travis CI config to test both `redux-saga` versions for each NodeJS version

### Preview

![image](https://user-images.githubusercontent.com/1246795/51788034-95d47900-2179-11e9-89d8-5f7879d80f39.png)
