### PR TITLE
Fix working eslint rule 'yield-effects' with static method of class

### DIFF
--- a/lib/rules/yield-effects.js
+++ b/lib/rules/yield-effects.js
@@ -25,6 +25,16 @@ module.exports = {
     var inGeneratorDepth = 0
     var effectLocalNames = []
     var effectImportedNames = []
+    function inGeneratorDepthIncrement(node) {
+      if (node.generator) {
+        ++inGeneratorDepth
+      }
+    }
+    function inGeneratorDepthDecrement(node) {
+      if (node.generator) {
+        --inGeneratorDepth
+      }
+    }
     return {
       "ImportDeclaration": function(node) {
         if (Effects.isEffectImport(node.source.value)) {
@@ -36,16 +46,10 @@ module.exports = {
           })
         }
       },
-      "FunctionDeclaration": function(node) {
-        if (node.generator) {
-          ++inGeneratorDepth
-        }
-      },
-      "FunctionDeclaration:exit": function(node) {
-        if (node.generator) {
-          --inGeneratorDepth
-        }
-      },
+      "FunctionDeclaration": inGeneratorDepthIncrement,
+      "FunctionDeclaration:exit": inGeneratorDepthDecrement,
+      "FunctionExpression": inGeneratorDepthIncrement,
+      "FunctionExpression:exit": inGeneratorDepthDecrement,
       "YieldExpression": function() {
         inYieldDepth += 1
       },

--- a/lib/rules/yield-effects.js
+++ b/lib/rules/yield-effects.js
@@ -25,12 +25,13 @@ module.exports = {
     var inGeneratorDepth = 0
     var effectLocalNames = []
     var effectImportedNames = []
-    function inGeneratorDepthIncrement(node) {
+
+    function enterFunction(node) {
       if (node.generator) {
         ++inGeneratorDepth
       }
     }
-    function inGeneratorDepthDecrement(node) {
+    function exitFunction(node) {
       if (node.generator) {
         --inGeneratorDepth
       }
@@ -46,10 +47,10 @@ module.exports = {
           })
         }
       },
-      "FunctionDeclaration": inGeneratorDepthIncrement,
-      "FunctionDeclaration:exit": inGeneratorDepthDecrement,
-      "FunctionExpression": inGeneratorDepthIncrement,
-      "FunctionExpression:exit": inGeneratorDepthDecrement,
+      "FunctionDeclaration": enterFunction,
+      "FunctionDeclaration:exit": exitFunction,
+      "FunctionExpression": enterFunction,
+      "FunctionExpression:exit": exitFunction,
       "YieldExpression": function() {
         inYieldDepth += 1
       },

--- a/test/lib/rules/yield-effects-spec.js
+++ b/test/lib/rules/yield-effects-spec.js
@@ -59,9 +59,9 @@ ruleTester.run("yield-effects", rule, {
       code: buildTest(
         "import { call, all, delay, fetchResources } from 'redux-saga'",
         "yield all([" +
-          "call(fetchResource, 'users')," +
-          "call(fetchResource, 'comments')," +
-          "call(delay, 1000)" +
+        "call(fetchResource, 'users')," +
+        "call(fetchResource, 'comments')," +
+        "call(delay, 1000)" +
         "])"
       )
     },
@@ -69,8 +69,17 @@ ruleTester.run("yield-effects", rule, {
       code:
         "import { takeEvery } from 'redux-saga';\n" +
         "export const fooSagas = [" +
-          "takeEvery('FOO_A', fooASaga)," +
-          "takeEvery('FOO_B', fooBSaga)];"
+        "takeEvery('FOO_A', fooASaga)," +
+        "takeEvery('FOO_B', fooBSaga)];"
+    },
+    {
+      code:
+        "import { call } from 'redux-saga';\n" +
+        "export class FooSaga {" +
+        "static* someSaga() {" +
+        "  yield call(() => {})" +
+        "}" +
+        "}"
     }
   ],
   invalid: [
@@ -93,6 +102,23 @@ ruleTester.run("yield-effects", rule, {
       code: buildTest("import { delay as d } from 'redux-saga'", "d('ACTION')"),
       output: buildTest("import { delay as d } from 'redux-saga'", "yield d('ACTION')"),
       errors: [{message: "d (delay) effect must be yielded"}]
+    },
+    {
+      code:
+        "import { call } from 'redux-saga';\n" +
+        "export class FooSaga {" +
+        "static* someSaga() {" +
+        "  call(() => {})" +
+        "}" +
+        "}",
+      output:
+        "import { call } from 'redux-saga';\n" +
+        "export class FooSaga {" +
+        "static* someSaga() {" +
+        "  yield call(() => {})" +
+        "}" +
+        "}",
+      errors: [{message: "call effect must be yielded"}]
     }
   ]
 })


### PR DESCRIPTION
We use in our project static method of classes for describing saga and eslint rule `yield-effects` of this plugin doesn't work with them.
For example, this code was correct before my fix:
```js
class SomeSaga(){
  static* someSagaMethod() {
     call(someService);
  }
}
```
As I understand, current realization of checker works with generator, which are only created by using function declaration.
For example:
```js
function* someSaga() {
   yield call(someService);
}
```

I've fix that with using `FunctionExpression` checking in eslint rule description.

Please, look at code for more information.