### PR TITLE
Allow spread operator in race effect

### DIFF
--- a/lib/rules/no-yield-in-race.js
+++ b/lib/rules/no-yield-in-race.js
@@ -8,6 +8,9 @@ function checkYieldInObject(context, node) {
   var properties = node.arguments[0].properties
   for (var i = 0, len = properties.length; i < len; ++i) {
     var property = properties[i]
+    if (property.type === "SpreadElement") {
+      continue;
+    }
     var name = property.key.name
     if (property.value.type === "YieldExpression") {
       var yieldExpression = property.value


### PR DESCRIPTION
@pke this is a simple patch that fixes the rule crashing - but all it does is `continue`s if there's a spread operator inside of `race` - it does not continue to try to detect the use of `yield`.