### PR TITLE
chore: release 1.3.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "eslint-plugin-redux-saga",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "eslint-plugin-redux-saga",
-      "version": "1.3.2",
+      "version": "1.3.3",
       "license": "MIT",
       "devDependencies": {
         "eslint": "8.57.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-redux-saga",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "redux-saga eslint rules",
   "author": "Philipp Kursawe <phil.kursawe+npm@gmail.com",
   "contributors": [


### PR DESCRIPTION
## Summary

- bump package version to 1.3.3
- publish the verified Dependabot cleanup through the trusted publisher workflow

## Verification

- Node 24: 45 tests passing
- npm package dry run: 8 intended files
- npm registry confirms 1.3.3 is unused
